### PR TITLE
Added four parameters, testing linked parameters

### DIFF
--- a/parameters.json
+++ b/parameters.json
@@ -1750,7 +1750,7 @@
     {
       "id": 141,
       "name": "comms_configuration_set",
-      "description": "A linked parameter list that defines a waveform code, bandwidth code and center frequency code - the integer parameter is a modem numnber for a node",
+      "description": "A linked parameter list that defines a waveform code, bandwidth code and center frequency code - the integer parameter is a modem number for a node",
       "representation": "uint16",
       "link_param": {
         "dry": {

--- a/parameters.json
+++ b/parameters.json
@@ -1707,6 +1707,64 @@
         }
       },
       "representation": "json"
+    },
+    {
+      "id": 126,
+      "name": "comms_waveform_ID_number",
+      "description": "Identifies what waveform is to be used for communication",
+      "access": {
+        "dry": {
+          "read": false,
+          "write": false,
+          "write_auth": true
+        }
+      },
+      "representation": "uint16"
+    },
+    {
+      "id": 127,
+      "name": "comms_bandwidth_code",
+      "description": "An integer code that identifies the bandwidth of the waveform to be used",
+      "access": {
+        "dry": {
+          "read": false,
+          "write": false,
+          "write_auth": true
+        }
+      },
+      "representation": "uint16"
+    },
+    {
+      "id": 128,
+      "name": "comms_center_frequency_code",
+      "description": "An integer code that identifies the center frequency of the waveform to be used",
+      "access": {
+        "dry": {
+          "read": false,
+          "write": false,
+          "write_auth": true
+        },
+        "representation": "uint16"
+      }
+    },
+    {
+      "id": 129,
+      "name": "comms_configuration_set",
+      "description": "A linked parameter list that defines a waveform code, bandwidth code and center frequency code - the integer parameter is a modem numnber for a node",
+      "representation": "uint16",
+      "link_id": {
+        "dry": {
+          "write": [ "comms_waveform_ID_number", "comms_bandwidth_code", "comms_center_frequency_code" ],
+          "read": [ "comms_waveform_ID_number", "comms_bandwidth_code", "comms_center_frequency_code" ]
+        }
+      },
+      "access": {
+        "dry": {
+          "read": true,
+          "write": true,
+          "write_auth": true
+        }
+      }
     }
   ]
 }

--- a/parameters.json
+++ b/parameters.json
@@ -767,7 +767,7 @@
           "read": true
         },
         "wet": {
-          "read": true,
+          "read": true
         }
       },
       "representation": "uint8"
@@ -879,11 +879,11 @@
       "access": {
         "dry": {
           "read": true,
-          "read_option": true,
+          "read_option": true
         },
         "wet": {
           "read": true,
-          "read_option": true,
+          "read_option": true
         }
       }
     },
@@ -1743,16 +1743,16 @@
           "read": false,
           "write": false,
           "write_auth": true
-        },
-        "representation": "uint16"
-      }
+        }
+      },
+      "representation": "uint16"
     },
     {
-      "id": 129,
+      "id": 141,
       "name": "comms_configuration_set",
       "description": "A linked parameter list that defines a waveform code, bandwidth code and center frequency code - the integer parameter is a modem numnber for a node",
       "representation": "uint16",
-      "link_id": {
+      "link_param": {
         "dry": {
           "write": [ "comms_waveform_ID_number", "comms_bandwidth_code", "comms_center_frequency_code" ],
           "read": [ "comms_waveform_ID_number", "comms_bandwidth_code", "comms_center_frequency_code" ]

--- a/parameters_schema.json
+++ b/parameters_schema.json
@@ -7,163 +7,210 @@
         "title": "parameter",
         "description": "A SWiG parameter",
         "type": "object",
-        "properties": {
-            "id": {
-                "description": "unique identifier",
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 255
-            },
-            "name": {
-                "description": "A machine-useable description of the parameter with no whitespace",
-                "type": "string",
-                "maximumLength": 256
-            },
-            "description": {
-                "description": "A human-readable description of the parameter",
-                "type": "string",
-                "maximumLength": 256
-            },
-            "representation": {
-                "description": "Data type of the parameter",
-                "type": "string",
-                "enum":[
-                    "uint8",
-                    "uint16",
-                    "uint32",
-                    "uint64",
-                    "int8",
-                    "int16",
-                    "int32",
-                    "int64",
-                    "utf-8 string",
-                    "bytearray",
-                    "boolean",
-                    "json"
-                ]
-            },
-            "minimum": {
-                "description": "Minimum integer value",
-                "type": "integer"
-            },
-            "maximum": {
-                "description": "Maximum integer value",
-                "type": "integer"
-            },
-            "pattern": {
-                "description": "Regular expression pattern which parameter values must match",
-                "type": "string"
-            },
-            "access": {
-                "description": "Permitted access to the parameter",
-                "type": "object",
-                "properties": {
-                    "dry": {
-                        "type": "object",
-                        "properties": {
-                            "read": {
-                                "type": "boolean"
-                            },
-                            "read_option": {
-                                "type": "boolean"
-                            },
-                            "read_auth": {
-                                "type": "boolean"
-                            },
-                            "write": {
-                                "type": "boolean"
-                            },
-                            "write_option": {
-                                "type": "boolean"
-                            },
-                            "write_auth": {
-                                "type": "boolean"
-                            }
-                        },
-                        "additionalProperties": false,
-                        "dependentRequired": {
-                            "read_option":["read"],
-                            "write_option":["write"],
-                            "read_auth":["read"],
-                            "write_auth":["write"]
-                        }
-                    },
-                    "wet": {
-                        "type": "object",
-                        "properties": {
-                            "read": {
-                                "type": "boolean"
-                            },
-                            "read_option": {
-                                "type": "boolean"
-                            },
-                            "read_auth": {
-                                "type": "boolean"
-                            },
-                            "write": {
-                                "type": "boolean"
-                            },
-                            "write_option": {
-                                "type": "boolean"
-                            },
-                            "write_auth": {
-                                "type": "boolean"
-                            }
-                        },
-                        "additionalProperties": false,
-                        "dependentRequired": {
-                            "read_option":["read"],
-                            "write_option":["write"],
-                            "read_auth":["read"],
-                            "write_auth":["write"]
-                        }
-                    }
-                },
-                "additionalProperties": false
-            },
-            "valid integers": {
-                "description": "Valid integers",
-                "type": "array",
-                "items": {
-                    "type": "integer"
-                },
-                "minItems": 1,
-                "uniqueItems": true
-            },
-            "valid strings": {
-                "description": "Valid strings",
-                "type": "array",
-                "items": {
-                    "type": "string"
-                },
-                "minItems": 1,
-                "uniqueItems": true
-            },
-            "optional": {
-                "description": "Technology optional",
-                "type": "object",
-                "properties": {
-                    "acoustic": {
-                        "type": "boolean"
-                    },
-                    "optical": {
-                        "type": "boolean"
-                    },
-                    "inductive": {
-                        "type": "boolean"
-                    },
-                    "radio": {
-                        "type": "boolean"
-                    },
-                    "no_power": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false,
-                "minItems": 1,
-                "uniqueItems": true
-            }
+      "properties": {
+        "id": {
+          "description": "unique identifier",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 255
         },
+        "name": {
+          "description": "A machine-useable description of the parameter with no whitespace",
+          "type": "string",
+          "maximumLength": 256
+        },
+        "description": {
+          "description": "A human-readable description of the parameter",
+          "type": "string",
+          "maximumLength": 256
+        },
+        "representation": {
+          "description": "Data type of the parameter",
+          "type": "string",
+          "enum": [
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "utf-8 string",
+            "bytearray",
+            "boolean",
+            "json"
+          ]
+        },
+        "minimum": {
+          "description": "Minimum integer value",
+          "type": "integer"
+        },
+        "maximum": {
+          "description": "Maximum integer value",
+          "type": "integer"
+        },
+        "pattern": {
+          "description": "Regular expression pattern which parameter values must match",
+          "type": "string"
+        },
+        "access": {
+          "description": "Permitted access to the parameter",
+          "type": "object",
+          "properties": {
+            "dry": {
+              "type": "object",
+              "properties": {
+                "read": {
+                  "type": "boolean"
+                },
+                "read_option": {
+                  "type": "boolean"
+                },
+                "read_auth": {
+                  "type": "boolean"
+                },
+                "write": {
+                  "type": "boolean"
+                },
+                "write_option": {
+                  "type": "boolean"
+                },
+                "write_auth": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false,
+              "dependentRequired": {
+                "read_option": [ "read" ],
+                "write_option": [ "write" ],
+                "read_auth": [ "read" ],
+                "write_auth": [ "write" ]
+              }
+            },
+            "wet": {
+              "type": "object",
+              "properties": {
+                "read": {
+                  "type": "boolean"
+                },
+                "read_option": {
+                  "type": "boolean"
+                },
+                "read_auth": {
+                  "type": "boolean"
+                },
+                "write": {
+                  "type": "boolean"
+                },
+                "write_option": {
+                  "type": "boolean"
+                },
+                "write_auth": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false,
+              "dependentRequired": {
+                "read_option": [ "read" ],
+                "write_option": [ "write" ],
+                "read_auth": [ "read" ],
+                "write_auth": [ "write" ]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "valid integers": {
+          "description": "Valid integers",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "valid strings": {
+          "description": "Valid strings",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "optional": {
+          "description": "Technology optional",
+          "type": "object",
+          "properties": {
+            "acoustic": {
+              "type": "boolean"
+            },
+            "optical": {
+              "type": "boolean"
+            },
+            "inductive": {
+              "type": "boolean"
+            },
+            "radio": {
+              "type": "boolean"
+            },
+            "no_power": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "link_param": {
+          "description": "Linked parameters by name",
+          "type": "object",
+          "properties": {
+            "dry": {
+              "type": "object",
+              "properties": {
+                "read": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                "write": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              },
+              "additionalProperties": false
+            },
+            "wet": {
+              "type": "object",
+              "properties": {
+                "read": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                "write": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
         "required": [ "id", "name", "description", "representation" ]
     },
     "additionalItems":false


### PR DESCRIPTION
Added:
1. comms_waveform_ID_number (example for SWiG L3:  SMAC, QPSK, OFDMBPSK1, etc. from draft standard
2. comms_bandwidth_code (a code that is used to indicate bandwidth - for some waveforms this might be in Hz, for others a value from a standard if bandwidths are highly quantized)
3. comms_center_frequency_code (a code that is used to indicate center frequency - for some waveforms this might be in 10s or 100s of Hz, or it might be from a standard if center frequencies are highly quantized)
4. comms_configuration_set - an atomic read/write of waveform ID, bandwidth ID, center frequency ID, with a specific modem number
